### PR TITLE
Registry with TLS

### DIFF
--- a/Docker/registry/Dockerfile
+++ b/Docker/registry/Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora:latest
+RUN dnf update -y
+RUN dnf install -y httpd mod_ssl
+RUN useradd pki
+RUN chmod 755 /home/pki
+RUN rm /etc/httpd/conf.d/welcome.conf
+#RUN chown -R pki:pki /home/pki/
+#RUN sed -i -e 's/dbhost=.*/dbhost=mariadb/' /home/i/i.conf
+EXPOSE 80
+USER pki
+WORKDIR /home/pki
+RUN mkdir ca srv
+USER root
+COPY ./run.sh /home/pki
+RUN chmod +x /home/pki/run.sh
+CMD ["./run.sh"]

--- a/Docker/registry/docker-compose.yml
+++ b/Docker/registry/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     registry:
         image:
           registry:2
+        ports:
+            - "5000:5000"
         environment:
             - REGISTRY_HTTP_TLS_CERTIFICATE=certs/repo.crt
             - REGISTRY_HTTP_TLS_KEY=certs/repo.key

--- a/Docker/registry/docker-compose.yml
+++ b/Docker/registry/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2"
+services:
+    web:
+        build:
+            context: .
+        ports:
+            - "80:80"
+        volumes:
+          - ./certs:/home/pki/srv
+        environment:
+          - PUBIP=TOTO
+    registry:
+        image:
+          registry:2
+        environment:
+            - REGISTRY_HTTP_TLS_CERTIFICATE=certs/repo.crt
+            - REGISTRY_HTTP_TLS_KEY=certs/repo.key
+        volumes:
+          - ./certs:/certs
+        restart: always

--- a/Docker/registry/run.sh
+++ b/Docker/registry/run.sh
@@ -2,7 +2,7 @@
 umask 277 && openssl genrsa 2048 > ca/ca.key
 umask 007 && openssl req -new -x509 -days 365 -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=ca" -key ca/ca.key > ca/ca.crt
 umask 002 && openssl genrsa 2048 > srv/repo.key
-umask 002 && openssl req -new -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=$PUBIP" -key srv/repo.key > srv/repo.csr
+umask 002 && openssl req -new -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=$PUBIP/subjectAltName=DNS.1=$PUBIP" -key srv/repo.key > srv/repo.csr
 umask 002 && openssl x509 -req -in srv/repo.csr -out srv/repo.crt -CA ca/ca.crt -CAkey ca/ca.key -CAcreateserial -CAserial ca/ca.srl
 cp /home/pki/ca/ca.crt /var/www/html
 chown pki:pki /var/www/html/ca.crt && chmod 644 /var/www/html/ca.crt

--- a/Docker/registry/run.sh
+++ b/Docker/registry/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+umask 277 && openssl genrsa 2048 > ca/ca.key
+umask 007 && openssl req -new -x509 -days 365 -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=ca" -key ca/ca.key > ca/ca.crt
+umask 002 && openssl genrsa 2048 > srv/repo.key
+umask 002 && openssl req -new -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=$PUBIP" -key srv/repo.key > srv/repo.csr
+umask 002 && openssl x509 -req -in srv/repo.csr -out srv/repo.crt -CA ca/ca.crt -CAkey ca/ca.key -CAcreateserial -CAserial ca/ca.srl
+cp /home/pki/ca/ca.crt /var/www/html
+chown pki:pki /var/www/html/ca.crt && chmod 644 /var/www/html/ca.crt
+/usr/sbin/apachectl -DFOREGROUND -k start

--- a/Docker/registry/run.sh
+++ b/Docker/registry/run.sh
@@ -18,7 +18,8 @@ umask 002 && openssl x509 -req -in srv/repo.csr \
    	-CA ca/ca.crt \
    	-CAkey ca/ca.key \
    	-CAcreateserial \
-   	-CAserial ca/ca.srl
+   	-CAserial ca/ca.srl \
+	-extensions v3_req -extfile /etc/pki/tls/openssl.cnf
 cp /home/pki/ca/ca.crt /var/www/html
 chown pki:pki /var/www/html/ca.crt && chmod 644 /var/www/html/ca.crt
 /usr/sbin/apachectl -DFOREGROUND -k start

--- a/Docker/registry/run.sh
+++ b/Docker/registry/run.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
+sed -i -e 's/# req_extensions = v3_req/req_extensions = v3_req/' /etc/pki/tls/openssl.cnf
+sed -i -e '/keyUsage = nonRepudiation, digitalSignature, keyEncipherment/ a subjectAltName = @alt_names' /etc/pki/tls/openssl.cnf
+cat << EOF >>/etc/pki/tls/openssl.cnf
+[alt_names]
+DNS.1 = $PUBIP
+EOF
+
 umask 277 && openssl genrsa 2048 > ca/ca.key
 umask 007 && openssl req -new -x509 -days 365 -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=ca" -key ca/ca.key > ca/ca.crt
 umask 002 && openssl genrsa 2048 > srv/repo.key
-umask 002 && openssl req -new -subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=$PUBIP/subjectAltName=DNS.1=$PUBIP" -key srv/repo.key > srv/repo.csr
-umask 002 && openssl x509 -req -in srv/repo.csr -out srv/repo.crt -CA ca/ca.crt -CAkey ca/ca.key -CAcreateserial -CAserial ca/ca.srl
+umask 002 && openssl req -new \
+   	-subj "/C=FR/ST=/L=Grenoble/O=HPE/CN=$PUBIP" \
+   	-key srv/repo.key \
+	> srv/repo.csr
+umask 002 && openssl x509 -req -in srv/repo.csr \
+   	-out srv/repo.crt \
+   	-CA ca/ca.crt \
+   	-CAkey ca/ca.key \
+   	-CAcreateserial \
+   	-CAserial ca/ca.srl
 cp /home/pki/ca/ca.crt /var/www/html
 chown pki:pki /var/www/html/ca.crt && chmod 644 /var/www/html/ca.crt
 /usr/sbin/apachectl -DFOREGROUND -k start


### PR DESCRIPTION
A bit raw, but it should setup:

1. A container with fedora to create the certs + apache to provide the CA cert at the web root.
2. A container with registry using TLS available on port 5000.


* You MUST use a real name (not the IP) there is a go bug that doesn't allow IP ! (spent 2h on that one)
* You need to put that name into the docker-compose.yml file within PUBIP env variable. (I will probably write a script to do that).
* You need to update your ca trust store.
* You need to restart docker service.

I will show you how it works tomorrow.

A+
Né²